### PR TITLE
Update README for minor command changes

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -116,21 +116,21 @@ It becomes fairly easy to start Kill Bill locally on your laptop. For example le
 2. Configure the database:
   First, modify the database to make sure it is using the `ROW` `binlog_format`:
   ```
-  echo "set global binlog_format = 'ROW'" | mysql -h $(docker-machine ip default) -uroot -p
+  echo "set global binlog_format = 'ROW'" | mysql -h $(docker-machine ip default) -u root -proot
   ```
   And then add the DDLs:
 
   * Kill Bill [DDL](http://docs.killbill.io/0.16/ddl.sql)
 
-    ```curl -s http://docs.killbill.io/0.16/ddl.sql | mysql -h $(docker-machine ip default) -Dkillbill -uroot -p root```
+    ```curl -s http://docs.killbill.io/0.16/ddl.sql | mysql -h $(docker-machine ip default) -D killbill -u root -proot```
 
   * Analytics [DDL](https://github.com/killbill/killbill-analytics-plugin/blob/master/src/main/resources/org/killbill/billing/plugin/analytics/ddl.sql)
 
-    ```curl -s https://raw.githubusercontent.com/killbill/killbill-analytics-plugin/master/src/main/resources/org/killbill/billing/plugin/analytics/ddl.sql | mysql -h $(docker-machine ip default) -D killbill -uroot -p root```
+    ```curl -s https://raw.githubusercontent.com/killbill/killbill-analytics-plugin/master/src/main/resources/org/killbill/billing/plugin/analytics/ddl.sql | mysql -h $(docker-machine ip default) -D killbill -u root -proot```
  
   * Stripe [DDL](https://github.com/killbill/killbill-stripe-plugin/blob/master/db/ddl.sql)
 
-    ```curl -s https://raw.githubusercontent.com/killbill/killbill-stripe-plugin/master/db/ddl.sql | mysql -h $(docker-machine ip default) -D killbill -uroot -p root```
+    ```curl -s https://raw.githubusercontent.com/killbill/killbill-stripe-plugin/master/db/ddl.sql | mysql -h $(docker-machine ip default) -D killbill -u root -proot```
 
     Note that the `-e MYSQL_DATABASE=killbill` argument to `docker run` above took care of creating the `killbill` database for us. When deploying to a production scenario, you'll need to do that step explicitly.
 
@@ -170,12 +170,17 @@ You can also install Kaui in a similar fashion:
 
   * Create a new database for KAUI
   ```
-  create database kaui;
+  echo "create database kaui;" | mysql -h $(docker-machine ip default) -u root -proot
   ```
 
   * Add the [DDL](https://raw.githubusercontent.com/killbill/killbill-admin-ui/master/db/ddl.sql) for KAUI
-
-  * Add the initial `admin` user in the `KAUI` database: `insert into kaui_allowed_users (kb_username, description, created_at, updated_at) values ('admin', 'super admin', NOW(), NOW());`
+  ```
+  curl -s https://raw.githubusercontent.com/killbill/killbill-admin-ui/master/db/ddl.sql | mysql -h $(docker-machine ip default) -D kaui -u root -proot
+  ```
+  * Add the initial `admin` user in the `KAUI` database: 
+  ```
+  echo "insert into kaui_allowed_users (kb_username, description, created_at, updated_at) values ('admin', 'super admin', NOW(), NOW());" | mysql -h $(docker-machine ip default) -D kaui -u root -proot
+  ```
 
   * Start the KAUI container:
 
@@ -190,7 +195,7 @@ You can also install Kaui in a similar fashion:
              -e KAUI_API_SECRET= \
              -e KAUI_CONFIG_DAO_URL=jdbc:mysql://dbserver:3306/kaui \
              -e KAUI_CONFIG_DAO_USER=root \
-             -e KAUI_CONFIG_DAO_PASSWORD= \
+             -e KAUI_CONFIG_DAO_PASSWORD=root \
              killbill/kaui:0.7.0
   ```
 


### PR DESCRIPTION
Commands under Local Development section were missing some values and spaces were needed between the option and value. Passwords (-p) MUST contain no space between -p and the value. 

Also made the KAUI section commands follow the pattern established in the previous sections.
